### PR TITLE
Add minecraft:mineable tags

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/mineable/axe.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "uncraftingtable76:uncraftingtable"
+    ]
+}

--- a/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "uncraftingtable76:uncraftingtable"
+    ]
+}


### PR DESCRIPTION
Add minecraft:mineable/pickaxe tag and minecraft:mineable/axe tag to the uncrafting table.

This solves issue #52 which was falsely claimed to be fixed by the actual dev but never got fixed.